### PR TITLE
[Adjustment] Allow Category on Coverage Search Combination

### DIFF
--- a/frontend/src/helpers/isSearchCombinationValid.ts
+++ b/frontend/src/helpers/isSearchCombinationValid.ts
@@ -37,6 +37,14 @@ export default function isSearchCombinationValid(
       (typeof businessTag === 'string' ||
         businessTag?.type === BusinessType.BUSINESS) &&
       (!hasLocationTag ||
+        (hasLocationTag && locationTag?.type !== LocationTagType.ADDRESS))
+    ) {
+      return true;
+    } else if (
+      hasBusinessTag &&
+      typeof businessTag !== 'string' &&
+      businessTag?.type === BusinessType.CATEGORY &&
+      (!hasLocationTag ||
         (hasLocationTag &&
           locationTag?.type !== LocationTagType.ADDRESS &&
           locationTag?.type !== LocationTagType.NATION))


### PR DESCRIPTION
previously only type business is allowed. now both business & category type are allowed with additional location logic