### PR TITLE
[Fix] Can't delete terminal card because overlap onPress

### DIFF
--- a/frontend/src/scenes/terminal/TerminalCard.tsx
+++ b/frontend/src/scenes/terminal/TerminalCard.tsx
@@ -100,6 +100,7 @@ export default function TerminalCard(props: Props) {
           <Button
             text="Delete"
             mode="transparent"
+            stopPropagation={true}
             onPress={() => {
               if (!isLandingPage) {
                 setDeletePopupVisible(true);


### PR DESCRIPTION
For issue #171 
![DeleteTerminalCard](https://user-images.githubusercontent.com/46436058/84493097-66240380-acd1-11ea-8ddc-3480a3ab0648.gif)
 