### PR TITLE
[Fix] Polling on error fix to flag

### DIFF
--- a/backend-node/src/resolvers/tables/activityQuery.ts
+++ b/backend-node/src/resolvers/tables/activityQuery.ts
@@ -100,6 +100,7 @@ let activityResolver: FieldResolver<'Query', 'activityTable'> = async (
         },
         data: {
           error: null,
+          updatedAt: todayMinOneH(),
         },
       });
       return {
@@ -249,6 +250,7 @@ let activityResolver: FieldResolver<'Query', 'activityTable'> = async (
               data: {
                 error: 'Failed to update Activity. Please try again.',
                 polling: false,
+                updatedAt: todayMinOneH(),
               },
             });
           });
@@ -326,6 +328,7 @@ let activityResolver: FieldResolver<'Query', 'activityTable'> = async (
           data: {
             error: 'Failed to update Activity. Please try again.',
             polling: false,
+            updatedAt: todayMinOneH(),
           },
         });
       });

--- a/backend-node/src/resolvers/tables/newsTableQuery.ts
+++ b/backend-node/src/resolvers/tables/newsTableQuery.ts
@@ -92,6 +92,7 @@ let newsTableResolver: FieldResolver<'Query', 'newsTable'> = async (
         },
         data: {
           error: null,
+          updatedAt: todayMinOneH(),
         },
       });
       return {
@@ -238,6 +239,7 @@ let newsTableResolver: FieldResolver<'Query', 'newsTable'> = async (
               data: {
                 error: 'Failed to update News. Please try again.',
                 polling: false,
+                updatedAt: todayMinOneH(),
               },
             });
           });
@@ -316,6 +318,7 @@ let newsTableResolver: FieldResolver<'Query', 'newsTable'> = async (
           data: {
             error: 'Failed to update News. Please try again.',
             polling: false,
+            updatedAt: todayMinOneH(),
           },
         });
       });

--- a/backend-node/src/resolvers/tables/performanceTableQuery.ts
+++ b/backend-node/src/resolvers/tables/performanceTableQuery.ts
@@ -98,6 +98,7 @@ let performanceTableResolver: FieldResolver<
         },
         data: {
           error: null,
+          updatedAt: todayMinOneH(),
         },
       });
       return {
@@ -261,6 +262,7 @@ let performanceTableResolver: FieldResolver<
               data: {
                 error: 'Failed to update Performance. Please try again.',
                 polling: false,
+                updatedAt: todayMinOneH(),
               },
             });
           });
@@ -352,6 +354,7 @@ let performanceTableResolver: FieldResolver<
           data: {
             error: 'Failed to update Performance. Please try again.',
             polling: false,
+            updatedAt: todayMinOneH(),
           },
         });
       });


### PR DESCRIPTION
Now if error occurred, the updatedAt will make the error table outdated. so if the table refetched, then they will try to updateData again because the updatedAt is outdated.

![SmallerPollError](https://user-images.githubusercontent.com/46436058/84637278-b1cbec80-af1f-11ea-8018-7d09676df142.gif)

