### PR TITLE
[Function] Make performance table to be one column for mobile

### DIFF
--- a/frontend/src/scenes/results/PerformanceTable.tsx
+++ b/frontend/src/scenes/results/PerformanceTable.tsx
@@ -162,7 +162,7 @@ export default function PerformanceTable(props: Props) {
           <DataTable.HeaderCell>{headerTitle}</DataTable.HeaderCell>
           <TouchableOpacity
             onPress={() => {
-              return setHeaderIndex(headerIndex - 1);
+              setHeaderIndex(headerIndex - 1);
             }}
             disabled={firstIndex}
           >


### PR DESCRIPTION
![MobliePerformanceTable](https://user-images.githubusercontent.com/46436058/85534756-cbfe7c80-b63b-11ea-9322-65286d6b5bb7.gif)
