### PR TITLE
[Fix] Fixing empty Comparison tag to become something else

### DIFF
--- a/backend-node/src/resolvers/compare/updateComparisonMutation.ts
+++ b/backend-node/src/resolvers/compare/updateComparisonMutation.ts
@@ -72,12 +72,8 @@ export let updateComparisonResolver: FieldResolver<
   }
   let comparationTags = await context.prisma.comparationTag.findMany({
     where: {
-      businessTag: selectedBusinessTag
-        ? { id: selectedBusinessTag.id }
-        : undefined,
-      locationTag: selectedLocationTag
-        ? { id: selectedLocationTag.id }
-        : undefined,
+      businessTag: selectedBusinessTag ? { id: selectedBusinessTag.id } : null,
+      locationTag: selectedLocationTag ? { id: selectedLocationTag.id } : null,
     },
     include: { businessTag: true, locationTag: true },
   });


### PR DESCRIPTION
Now adding comparison with empty tag won't change to something else tag.
#456 